### PR TITLE
enable cirque unit test in github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,4 @@ jobs:
         sudo pip3 install protobuf==3.12.0
         make pretty-check
         make install-develop
+        sudo ./run_tests.sh

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -129,8 +129,8 @@ function run_unit_tests() {
   source "${VENV}"/bin/activate
   export PATH="${PATH}":"${OPENTHREAD_DIR}"/output/x86_64-unknown-linux-gnu/bin/
   python3 cirque/capabilities/test/test_mount_capability.py
-  python3 cirque/capabilities/test/test_wifi_capability.py
-  python3 cirque/home/test/test_home.py
+  # python3 cirque/capabilities/test/test_wifi_capability.py
+  # python3 cirque/home/test/test_home.py
   deactivate
 }
 
@@ -141,16 +141,17 @@ function main() {
   create_virtual_environment
   install_cirque_to_venv
   run_unit_tests
-  sleep 5
-  run_flask_virtual_home_test
   testexit=$?
-  run_flask_clean
-  if [[ $testexit -gt 0 ]]; then
-    exit 1
-  fi
-  sleep 5
-  run_grpc_virtual_home_test
-  run_grpc_clean
+  #sleep 5
+  # run_flask_virtual_home_test
+  # testexit=$?
+  # run_flask_clean
+  # if [[ $testexit -gt 0 ]]; then
+  #  exit 1
+  #fi
+  #sleep 5
+  #run_grpc_virtual_home_test
+  #run_grpc_clean
   if [[ $testexit -gt 0 ]]; then
     exit 1
   fi


### PR DESCRIPTION
Summmary of Changes:
-- github action don't support hw80211 virtual wifi, we disable virtual
wifi related test, and run limited number of cirque unit test in github