### PR TITLE
Require pylint version to be at least 2.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ grpcio-tools
 grpcio-status == 1.30.0
 protobuf >= 3.12.0, < 4.0.0
 pycodestyle >= 2.5.0
-pylint == 2.4
+pylint >= 2.5.1
 pyroute2 >= 0.5.7
 six >= 1.12
 toml

--- a/requirements_nogrpc.txt
+++ b/requirements_nogrpc.txt
@@ -1,7 +1,7 @@
 docker >= 4.1.0
 flask >= 1.1.0
 pycodestyle >= 2.5.0
-pylint == 2.4
+pylint >= 2.5.1
 pyroute2 >= 0.5.7
 six >= 1.12
 toml

--- a/utils/pystyletest/styletest.py
+++ b/utils/pystyletest/styletest.py
@@ -16,7 +16,7 @@ import sys
 import pylint.lint
 import pycodestyle
 
-pylint.lint.Run(sys.argv[1:], do_exit=False)
+pylint.lint.Run(sys.argv[1:], exit=False)
 print()
 print('---------------PEP8---------------')
 pep8style = pycodestyle.StyleGuide(quiet=False)


### PR DESCRIPTION
Requiring pylint==2.4.0 might downgrade pylint on most recent Linux distributions, e.g. Ubuntu 22.04 is shipped with pylint-2.12.2.

From pylint version 2.5.1 onward the `do_exit` argument of the `Run` class has been changed to `exit` and the former one is marked as deprecated.